### PR TITLE
Add feedback endpoint and tooling

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,137 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+from typing import Optional
+import os
+import json
+import subprocess
+import sys
+import psycopg
+
+from search_answer import answer as answer_single
+from search_chat import chat_respond
+
+DB_URL = os.getenv("DATABASE_URL")
+APP_DIR = os.path.dirname(__file__)
+app = FastAPI(title="Sophia RAG API", version="1.1")
+
+class AskIn(BaseModel):
+    question: str
+    top_k: Optional[int] = None
+
+class ChatIn(BaseModel):
+    session: str
+    message: str
+
+class AnalyzeIn(BaseModel):
+    path: Optional[str] = None
+    doc_id: Optional[int] = None
+    k: Optional[int] = 40
+
+class AnalyzeBatchIn(BaseModel):
+    prefix: Optional[str] = None
+    limit: Optional[int] = 50
+
+class FeedbackIn(BaseModel):
+    query_hash: str
+    doc_id: int = Field(gt=0)
+    signal: int = Field(ge=-1, le=1)
+
+@app.get("/health")
+def health():
+    try:
+        with psycopg.connect(DB_URL) as conn, conn.cursor() as cur:
+            cur.execute("select 1")
+            cur.fetchone()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"DB error: {e}")
+    return {"ok": True}
+
+@app.post("/ask")
+def ask(inp: AskIn):
+    ans, cites, qhash = answer_single(
+        inp.question,
+        k=inp.top_k or int(os.getenv("TOPK", "12")),
+        return_metadata=True,
+    )
+    return {"answer": ans, "citations": cites, "query_hash": qhash}
+
+@app.post("/chat")
+def chat(inp: ChatIn):
+    ans, cites, qhash = chat_respond(inp.session, inp.message)
+    return {"answer": ans, "citations": cites, "query_hash": qhash}
+
+@app.post("/analyze_doc")
+def analyze_doc(inp: AnalyzeIn):
+    cmd = [sys.executable, "-u", os.path.join(APP_DIR, "analyze_doc.py")]
+    if inp.path:
+        cmd += ["--path", inp.path]
+    if inp.doc_id is not None:
+        cmd += ["--doc_id", str(inp.doc_id)]
+    if inp.k:
+        cmd += ["--k", str(inp.k)]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        raise HTTPException(status_code=500, detail=r.stderr.strip())
+    try:
+        return json.loads(r.stdout.strip())
+    except Exception:
+        return {"ok": True, "raw": r.stdout.strip()}
+
+@app.post("/analyze_batch")
+def analyze_batch(inp: AnalyzeBatchIn):
+    cmd = [sys.executable, "-u", os.path.join(APP_DIR, "analyze_batch.py")]
+    if inp.prefix:
+        cmd += ["--prefix", inp.prefix]
+    if inp.limit:
+        cmd += ["--limit", str(inp.limit)]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        raise HTTPException(status_code=500, detail=r.stderr.strip())
+    try:
+        return json.loads(r.stdout.strip())
+    except Exception:
+        return {"ok": True, "raw": r.stdout.strip()}
+
+@app.post("/feedback")
+def feedback(inp: FeedbackIn):
+    try:
+        with psycopg.connect(DB_URL) as conn, conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO feedback(query_hash, doc_id, signal) VALUES (%s,%s,%s)",
+                (inp.query_hash, inp.doc_id, inp.signal),
+            )
+            conn.commit()
+    except psycopg.Error as exc:
+        raise HTTPException(status_code=500, detail=f"DB error: {exc.pgerror or exc}") from exc
+    return {"ok": True}
+
+@app.get("/analysis")
+def analysis(path: Optional[str] = None, limit: int = 50):
+    with psycopg.connect(DB_URL) as conn, conn.cursor() as cur:
+        if path:
+            cur.execute("SELECT * FROM doc_analysis WHERE path=%s", (path,))
+            row = cur.fetchone()
+            if not row:
+                raise HTTPException(status_code=404, detail="not found")
+            cols = [d[0] for d in cur.description]
+            return dict(zip(cols, row))
+        cur.execute(
+            "SELECT path, summary, created_at FROM doc_analysis ORDER BY created_at DESC LIMIT %s",
+            (limit,),
+        )
+        return [
+            {"path": p, "summary": s, "created_at": c.isoformat()}
+            for p, s, c in cur.fetchall()
+        ]
+
+@app.get("/report")
+def report(prefix: Optional[str] = None, limit: int = 100):
+    cmd = [sys.executable, "-u", os.path.join(APP_DIR, "report_builder.py")]
+    if prefix:
+        cmd += ["--prefix", prefix]
+    if limit:
+        cmd += ["--limit", str(limit)]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        raise HTTPException(status_code=500, detail=r.stderr.strip())
+    return {"markdown": r.stdout}

--- a/app/record_feedback.py
+++ b/app/record_feedback.py
@@ -1,0 +1,50 @@
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_API = os.getenv("API_URL") or f"http://127.0.0.1:{os.getenv('API_PORT', '18888')}"
+
+
+def post_feedback(api_url: str, query_hash: str, doc_id: int, signal: int) -> dict:
+    payload = json.dumps({
+        "query_hash": query_hash,
+        "doc_id": doc_id,
+        "signal": signal,
+    }).encode("utf-8")
+    url = api_url.rstrip("/") + "/feedback"
+    req = urllib.request.Request(url, data=payload, headers={"Content-Type": "application/json"}, method="POST")
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        body = resp.read().decode("utf-8")
+        if not body:
+            return {"ok": resp.status < 300, "status": resp.status}
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError:
+            return {"ok": resp.status < 300, "status": resp.status, "raw": body}
+        data.setdefault("status", resp.status)
+        return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Enviar feedback de relevância para a API da Sophia.")
+    parser.add_argument("query_hash", help="Hash da pergunta (sha256)")
+    parser.add_argument("doc_id", type=int, help="ID do chunk (docs.id)")
+    parser.add_argument("signal", type=int, choices=[-1, 0, 1], help="Sinal do feedback")
+    parser.add_argument("--api-url", dest="api_url", default=DEFAULT_API, help="Endpoint base da API (default: %(default)s)")
+    args = parser.parse_args(argv)
+
+    try:
+        result = post_feedback(args.api_url, args.query_hash, args.doc_id, args.signal)
+    except urllib.error.URLError as exc:
+        print(f"Falha ao enviar feedback: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, ensure_ascii=False))
+    return 0 if result.get("ok") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app/search_answer.py
+++ b/app/search_answer.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+import os
+from dotenv import load_dotenv
+from openai import OpenAI
+from search_utils import (
+    embed_query,
+    expand_query,
+    retrieve_hybrid,
+    rerank_pairs,
+    apply_glossary_boost,
+    inject_notes,
+    try_cache,
+    save_cache,
+    self_rag_verify,
+    sha,
+)
+
+load_dotenv(Path(__file__).with_name(".env"), override=True)
+GEN_MODEL = os.getenv("GEN_MODEL", "gpt-5")
+REASONING_EFFORT = os.getenv("REASONING_EFFORT", "high")
+EMBED_MODEL = os.getenv("EMBED_MODEL", "text-embedding-3-small")
+TOPK = int(os.getenv("TOPK", "12"))
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+PROMPT = """
+Você é um analista jurídico-regulatório. Responda usando apenas o contexto abaixo.
+- Faça um resumo crítico.
+- Liste favoráveis e contrários com justificativas.
+- Compare documentos quando houver divergências/convergências.
+- Cite fontes como [#n] + caminho.
+- Se faltar base, diga o que falta.
+
+Pergunta: "{question}"
+
+Contexto:
+{contexts}
+"""
+
+def answer(question, k=TOPK, max_ctx_chars=20000, return_metadata=False):
+    qhash = sha(question)
+    row = try_cache(question)
+    if row:
+        answer_text = row["answer"]
+        citations = row.get("citations") or []
+        if return_metadata:
+            return answer_text, citations, qhash
+        print(answer_text)
+        return
+
+    variants = expand_query(question)
+    all_rows = []
+    for v in variants:
+        qvec = embed_query(v, os.getenv("EMBED_MODEL", "text-embedding-3-small"))
+        rows = retrieve_hybrid(v, qvec, k=k)
+        all_rows.extend(rows)
+    by_id = {r["id"]: r for r in all_rows}
+    rows = list(by_id.values())
+    rows = apply_glossary_boost(question, rows)
+    rows = inject_notes(rows)
+    rows = rerank_pairs(question, rows)
+
+    blocks = []
+    total = 0
+    cites = []
+    for i, r in enumerate(rows[:k], 1):
+        header = f"[#{i}] {r['path']} (chunk {r['chunk_no']})"
+        body = (r["content"] or "").replace("\n", " ").strip()
+        piece = f"{header}\n{body}\n"
+        if total + len(piece) > max_ctx_chars:
+            break
+        blocks.append(piece)
+        total += len(piece)
+        cites.append(
+            {
+                "n": i,
+                "id": r["id"],
+                "path": r["path"],
+                "chunk": r["chunk_no"],
+            }
+        )
+    contexts = "\n---\n".join(blocks)
+    user_prompt = PROMPT.format(question=question, contexts=contexts)
+    resp = client.chat.completions.create(
+        model=GEN_MODEL,
+        messages=[
+            {
+                "role": "system",
+                "content": "Responda tecnicamente, sem inventar fatos, e cite fontes.",
+            },
+            {"role": "user", "content": user_prompt},
+        ],
+        temperature=0.2,
+        reasoning={"effort": REASONING_EFFORT},
+    )
+    draft = resp.choices[0].message.content
+    final = self_rag_verify(draft, contexts)
+    save_cache(question, final, cites)
+
+    if return_metadata:
+        return final, cites, qhash
+
+    print(final)
+
+if __name__ == "__main__":
+    import sys
+
+    q = " ".join(sys.argv[1:]) or "Quais entendimentos favoráveis e contrários sobre [tema]?"
+    answer(q)

--- a/app/search_chat.py
+++ b/app/search_chat.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+import os
+import json
+from dotenv import load_dotenv
+from openai import OpenAI
+from search_utils import (
+    retrieve_hybrid,
+    apply_glossary_boost,
+    inject_notes,
+    rerank_pairs,
+    self_rag_verify,
+    sha,
+)
+
+load_dotenv(Path(__file__).with_name(".env"), override=True)
+GEN_MODEL = os.getenv("GEN_MODEL", "gpt-5")
+REASONING_EFFORT = os.getenv("REASONING_EFFORT", "high")
+EMBED_MODEL = os.getenv("EMBED_MODEL", "text-embedding-3-small")
+TOPK = int(os.getenv("TOPK", "12"))
+SESS_DIR = Path("/opt/rag-sophia/sessions")
+SESS_DIR.mkdir(parents=True, exist_ok=True)
+SYSTEM = "Você é um assistente analítico. Baseie-se no contexto recuperado e no histórico. Cite fontes como [#n] + caminho."
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+
+def chat_respond(session_name: str, user_text: str):
+    qhash = sha(user_text)
+    qvec = client.embeddings.create(model=EMBED_MODEL, input=user_text).data[0].embedding
+    rows = retrieve_hybrid(user_text, qvec, k=TOPK)
+    seen = set()
+    uniq = []
+    for r in rows:
+        if r["id"] in seen:
+            continue
+        seen.add(r["id"])
+        uniq.append(r)
+    rows = apply_glossary_boost(user_text, uniq)
+    rows = inject_notes(rows)
+    rows = rerank_pairs(user_text, rows)
+    blocks = []
+    cites = []
+    total = 0
+    max_ctx = 18000
+    for i, r in enumerate(rows[:TOPK], 1):
+        header = f"[#{i}] {r['path']} (chunk {r['chunk_no']})"
+        body = (r["content"] or "").replace("\n", " ").strip()
+        piece = f"{header}\n{body}\n"
+        if total + len(piece) > max_ctx:
+            break
+        blocks.append(piece)
+        total += len(piece)
+        cites.append(
+            {
+                "n": i,
+                "id": r["id"],
+                "path": r["path"],
+                "chunk": r["chunk_no"],
+            }
+        )
+    contexts = "\n---\n".join(blocks)
+    prompt = (
+        f"Pergunta: \"{user_text}\"\n\nContexto recuperado:\n{contexts}\n\n"
+        "Regras:\n- Seja específico e crítico.\n- Liste prós/contras quando fizer sentido.\n"
+        "- Cite fontes como [#n] + caminho.\n- Se faltar base, diga o que falta."
+    )
+    resp = client.chat.completions.create(
+        model=GEN_MODEL,
+        messages=[{"role": "system", "content": SYSTEM}, {"role": "user", "content": prompt}],
+        temperature=0.2,
+        reasoning={"effort": REASONING_EFFORT},
+    )
+    draft = resp.choices[0].message.content or "(sem conteúdo)"
+    final = self_rag_verify(draft, contexts)
+    return final, cites, qhash
+
+if __name__ == "__main__":
+    import sys
+
+    sess = sys.argv[1] if len(sys.argv) > 1 else "sess"
+    question = " ".join(sys.argv[2:]) if len(sys.argv) > 2 else "Pergunta?"
+    ans, cites, qhash = chat_respond(sess, question)
+    print(json.dumps({"answer": ans, "cites": cites, "query_hash": qhash}, ensure_ascii=False))

--- a/app/search_utils.py
+++ b/app/search_utils.py
@@ -1,0 +1,210 @@
+import os
+import json
+import hashlib
+from openai import OpenAI
+import psycopg
+from psycopg.rows import dict_row
+
+client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+DB_URL = os.getenv("DATABASE_URL")
+GEN_MODEL = os.getenv("GEN_MODEL", "gpt-5")
+EXP_MODEL = os.getenv("EXPANSION_MODEL", GEN_MODEL)
+REASONING_EFFORT = os.getenv("REASONING_EFFORT", "high")
+TOPK = int(os.getenv("TOPK", "12"))
+EXPANSIONS = int(os.getenv("EXPANSIONS", "4"))
+RERANK_TOP = int(os.getenv("RERANK_TOP", "24"))
+SELF_RAG = os.getenv("SELF_RAG", "true").lower() == "true"
+USE_QA_CACHE = os.getenv("USE_QA_CACHE", "true").lower() == "true"
+QA_CACHE_TTL_DAYS = int(os.getenv("QA_CACHE_TTL_DAYS", "90"))
+FEEDBACK_ALPHA = float(os.getenv("FEEDBACK_ALPHA", "0.15"))
+GLOSSARY_BOOST = float(os.getenv("GLOSSARY_BOOST", "0.2"))
+NOTES_BOOST = float(os.getenv("NOTES_BOOST", "0.35"))
+EMBED_DIM = int(os.getenv("EMBED_DIM", "1536"))
+
+SQL_BASE = f"""
+WITH q AS (
+  SELECT websearch_to_tsquery('portuguese', %(q)s) AS tsq,
+         %(qvec)s::vector({EMBED_DIM}) AS qvec
+),
+lex AS (
+  SELECT id, ts_rank_cd(d.tsv, q.tsq) AS lscore
+  FROM docs d, q
+  WHERE d.tsv @@ q.tsq
+  ORDER BY lscore DESC
+  LIMIT 300
+),
+vec AS (
+  SELECT id, 1 - (d.embedding <=> q.qvec) AS vscore
+  FROM docs d, q
+  WHERE d.embedding IS NOT NULL
+  ORDER BY d.embedding <=> q.qvec
+  LIMIT 300
+),
+u AS (
+  SELECT COALESCE(lex.id, vec.id) AS id,
+         COALESCE(lex.lscore, 0) AS lscore,
+         COALESCE(vec.vscore, 0) AS vscore
+),
+joined AS (
+  SELECT d.id, d.path, d.chunk_no, d.title, d.meta, d.content,
+         (0.6 * lscore + 0.4 * vscore) AS base_score
+  FROM u JOIN docs d ON d.id = u.id
+),
+fb AS (
+  SELECT doc_id, SUM(signal)::REAL AS fscore FROM feedback GROUP BY doc_id
+)
+SELECT j.*, COALESCE(fb.fscore, 0) AS fscore
+FROM joined j
+LEFT JOIN fb ON fb.doc_id = j.id
+ORDER BY base_score DESC
+LIMIT %(n)s;
+"""
+
+def sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", errors="ignore")).hexdigest()
+
+def embed_query(q: str, embed_model: str):
+    return client.embeddings.create(model=embed_model, input=q).data[0].embedding
+
+def expand_query(q: str) -> list[str]:
+    if EXPANSIONS <= 0:
+        return [q]
+    prompt = f"Gere {EXPANSIONS} variações curtas e técnicas para a consulta abaixo, uma por linha.\n\nConsulta: {q}"
+    r = client.chat.completions.create(
+        model=EXP_MODEL,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.3,
+    )
+    lines = [l.strip("-• ").strip() for l in r.choices[0].message.content.splitlines() if l.strip()]
+    uniq: list[str] = []
+    seen: set[str] = set()
+    for s in [q] + lines:
+        if s not in seen:
+            uniq.append(s)
+            seen.add(s)
+        if len(uniq) >= EXPANSIONS + 1:
+            break
+    return uniq
+
+def rerank_pairs(question: str, items: list[dict]) -> list[dict]:
+    if not items:
+        return items
+    chunks = items[: int(os.getenv("RERANK_TOP", "24"))]
+    trechos = "\n".join([f"[{i}] {c['content'][:800]}" for i, c in enumerate(chunks)])
+    msgs = [
+        {
+            "role": "system",
+            "content": "Dê nota 0..10 para relevância de cada trecho vs pergunta. Responda JSON: [{idx,score}]",
+        },
+        {
+            "role": "user",
+            "content": "Pergunta: " + question + "\n\nTrechos:\n" + trechos,
+        },
+    ]
+    r = client.chat.completions.create(model=EXP_MODEL, messages=msgs, temperature=0)
+    try:
+        scores = json.loads(r.choices[0].message.content)
+        for s in scores:
+            idx = s.get("idx")
+            sc = float(s.get("score", 0))
+            if isinstance(idx, int) and 0 <= idx < len(chunks):
+                chunks[idx]["rerank"] = sc
+    except Exception:
+        for i, _ in enumerate(chunks):
+            chunks[i]["rerank"] = 0.0
+    for i in range(len(chunks), len(items)):
+        items[i]["rerank"] = 0.0
+    for it in items:
+        it["final_score"] = it.get("base_score", 0) + FEEDBACK_ALPHA * it.get("fscore", 0) + (it.get("rerank", 0) / 10.0)
+    items.sort(key=lambda x: x["final_score"], reverse=True)
+    return items
+
+def apply_glossary_boost(question: str, rows: list[dict]):
+    if GLOSSARY_BOOST <= 0:
+        return rows
+    terms = []
+    with psycopg.connect(DB_URL) as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute("SELECT term, weight FROM glossary")
+        terms = cur.fetchall()
+    ql = question.lower()
+    for r in rows:
+        bonus = 0.0
+        txt = (r.get("content") or "").lower()
+        for t in terms:
+            term = t["term"].lower()
+            w = float(t["weight"] or 1.0)
+            if term in ql or term in txt:
+                bonus += GLOSSARY_BOOST * w * 0.1
+        r["base_score"] += bonus
+    return rows
+
+def inject_notes(rows: list[dict]):
+    if NOTES_BOOST <= 0:
+        return rows
+    with psycopg.connect(DB_URL) as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute("SELECT id, text FROM notes ORDER BY created_at DESC LIMIT 50;")
+        ns = cur.fetchall()
+    for n in ns:
+        rows.append(
+            {
+                "id": 10_000_000 + n["id"],
+                "path": f"NOTE:{n['id']}",
+                "chunk_no": 0,
+                "title": "Nota",
+                "meta": {},
+                "content": n["text"],
+                "base_score": NOTES_BOOST,
+                "fscore": 0.0,
+            }
+        )
+    return rows
+
+def try_cache(question: str):
+    if not USE_QA_CACHE:
+        return None
+    with psycopg.connect(DB_URL) as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """SELECT answer, citations, created_at FROM qa_cache
+                       WHERE qhash=%s AND created_at >= now() - interval '%s days'""",
+            (sha(question), os.getenv("QA_CACHE_TTL_DAYS", "90")),
+        )
+        return cur.fetchone()
+
+def save_cache(question: str, answer: str, citations: list[dict]):
+    if not USE_QA_CACHE:
+        return
+    with psycopg.connect(DB_URL) as conn, conn.cursor() as cur:
+        cur.execute(
+            """INSERT INTO qa_cache(qhash,question,answer,citations,created_at)
+                       VALUES(%s,%s,%s,%s,now())
+                       ON CONFLICT (qhash) DO UPDATE SET
+                         question=EXCLUDED.question, answer=EXCLUDED.answer,
+                         citations=EXCLUDED.citations, created_at=now()""",
+            (sha(question), question, answer, psycopg.types.json.Json(citations)),
+        )
+        conn.commit()
+
+def self_rag_verify(draft: str, contexts: str) -> str:
+    if os.getenv("SELF_RAG", "true").lower() != "true":
+        return draft
+    prompt = f"""Revise a resposta abaixo, mantendo apenas afirmações suportadas pelo CONTEXTO.
+Se algo não estiver claramente suportado, remova ou marque como incerto. Mantenha as citações [#n].
+RESPOSTA:\n{draft}\n\nCONTEXTO:\n{contexts}"""
+    r = client.chat.completions.create(
+        model=GEN_MODEL,
+        messages=[
+            {"role": "system", "content": "Você é um verificador factual rigoroso."},
+            {"role": "user", "content": prompt},
+        ],
+        temperature=0.0,
+    )
+    return r.choices[0].message.content
+
+def retrieve_hybrid(question: str, qvec, k: int = TOPK) -> list[dict]:
+    with psycopg.connect(DB_URL) as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute("SET hnsw.ef_search=100;")
+        cur.execute(
+            SQL_BASE,
+            {"q": question, "qvec": qvec, "n": max(k * 3, int(os.getenv("RERANK_TOP", "24")))},
+        )
+        return cur.fetchall()

--- a/chat_tui.sh
+++ b/chat_tui.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+BASE="/opt/rag-sophia"
+APP="$BASE/app"
+SESSION="${1:-sess_$(date +%Y%m%d_%H%M%S)}"
+LAST_RESULT_JSON=""
+API_ENDPOINT=""
+
+ensure_api_key(){
+  . "$APP/.env"
+  if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+    if command -v dialog >/dev/null 2>&1; then
+      dialog --inputbox "Informe sua OPENAI_API_KEY" 10 70 "" 2>/.tmp.key || exit 1
+      KEY="$(cat /.tmp.key)"
+    else
+      KEY=$(whiptail --inputbox "Informe sua OPENAI_API_KEY" 10 70 "" 3>&1 1>&2 2>&3) || exit 1
+    fi
+    [[ -z "$KEY" ]] && exit 1
+    sed -i "s/^OPENAI_API_KEY=.*/OPENAI_API_KEY=$KEY/" "$APP/.env"
+  fi
+}
+
+start_stack(){
+  systemctl start sophia-api >/dev/null 2>&1 || true
+  cd "$BASE"
+  docker compose up -d >/dev/null 2>&1 || true
+}
+
+show_box(){
+  local title="$1" body="$2"
+  if command -v dialog >/dev/null 2>&1; then
+    dialog --title "$title" --msgbox "$body" 25 100
+  else
+    whiptail --scrolltext --title "$title" --msgbox "$body" 25 100
+  fi
+}
+
+show_alert(){
+  local title="$1" body="$2"
+  if command -v dialog >/dev/null 2>&1; then
+    dialog --title "$title" --msgbox "$body" 12 80
+  else
+    whiptail --title "$title" --msgbox "$body" 12 80
+  fi
+}
+
+detect_api_url(){
+  if [[ -n "${API_URL:-}" ]]; then
+    API_ENDPOINT="${API_URL%%/}"
+    return
+  fi
+  if [[ -n "${API_PORT:-}" ]]; then
+    API_ENDPOINT="http://127.0.0.1:${API_PORT}"
+    return
+  fi
+  if [[ -f "$APP/.env" ]]; then
+    local from_env
+    from_env="$(grep -E '^API_URL=' "$APP/.env" | tail -n1 | cut -d= -f2-)"
+    if [[ -n "$from_env" ]]; then
+      API_ENDPOINT="${from_env%%/}"
+      return
+    fi
+    from_env="$(grep -E '^API_PORT=' "$APP/.env" | tail -n1 | cut -d= -f2-)"
+    if [[ -n "$from_env" ]]; then
+      API_ENDPOINT="http://127.0.0.1:${from_env}"
+      return
+    fi
+  fi
+  API_ENDPOINT="http://127.0.0.1:18888"
+}
+
+send_question(){
+  ensure_api_key
+  local q ans tmp
+  if command -v dialog >/dev/null 2>&1; then
+    dialog --inputbox "Digite sua pergunta" 12 78 "" 2>/.tmp.q || return
+    q="$(cat /.tmp.q)"
+  else
+    q=$(whiptail --inputbox "Digite sua pergunta" 12 78 --title "💬 Nova pergunta" 3>&1 1>&2 2>&3) || return
+  fi
+  [[ -z "$q" ]] && return
+  tmp="$(mktemp)"
+  cd "$APP"
+  source .venv/bin/activate
+  export $(grep -v '^#' .env | xargs -d '\n' -I{} echo {} | sed 's/\r$//')
+  python -u - "$SESSION" "$q" > "$tmp" 2>&1 <<'PY'
+import sys, json
+from search_chat import chat_respond
+ans, cites, qhash = chat_respond(sys.argv[1], sys.argv[2])
+print(json.dumps({"answer": ans, "cites": cites, "query_hash": qhash}, ensure_ascii=False))
+PY
+  if jq -e . >/dev/null 2>&1 <"$tmp"; then
+    LAST_RESULT_JSON="$(cat "$tmp")"
+    ans="$(printf '%s' "$LAST_RESULT_JSON" | jq -r '.answer' 2>/dev/null)"
+  else
+    LAST_RESULT_JSON=""
+    ans="$(tail -n 200 "$tmp")"
+  fi
+  [[ -z "$ans" ]] && ans="(sem resposta / verifique logs)"
+  show_box "🤖 Resposta" "$ans"
+  rm -f "$tmp"
+}
+
+choose_from_menu(){
+  local title="$1" prompt="$2"; shift 2
+  local choice
+  if command -v dialog >/dev/null 2>&1; then
+    choice=$(dialog --stdout --title "$title" --menu "$prompt" 22 90 10 "$@") || return 1
+  else
+    choice=$(whiptail --title "$title" --menu "$prompt" 22 90 10 "$@" 3>&1 1>&2 2>&3) || return 1
+  fi
+  printf '%s' "$choice"
+}
+
+send_feedback(){
+  if [[ -z "$LAST_RESULT_JSON" ]]; then
+    show_alert "Feedback" "Envie uma pergunta antes de registrar feedback."
+    return
+  fi
+  local qhash
+  qhash="$(printf '%s' "$LAST_RESULT_JSON" | jq -r '.query_hash // empty')"
+  if [[ -z "$qhash" ]]; then
+    show_alert "Feedback" "Resposta atual não possui identificador de consulta."
+    return
+  fi
+  local cites_json
+  cites_json="$(printf '%s' "$LAST_RESULT_JSON" | jq -c '.cites // .citations // []')"
+  if [[ "$(printf '%s' "$cites_json" | jq 'length')" -eq 0 ]]; then
+    show_alert "Feedback" "Resposta atual não possui citações para avaliar."
+    return
+  fi
+  local menu_items=()
+  while IFS=$'\n' read -r line; do
+    [[ -z "$line" ]] && continue
+    local doc_id="${line%%|*}"
+    local label="${line#*|}"
+    menu_items+=("$doc_id" "$label")
+  done < <(printf '%s' "$cites_json" | jq -r '.[] | "\(.id)|[#\(.n)] \(.path) (chunk \(.chunk))"')
+  if [[ ${#menu_items[@]} -eq 0 ]]; then
+    show_alert "Feedback" "Não foi possível montar a lista de citações."
+    return
+  fi
+  local selected
+  selected=$(choose_from_menu "Feedback" "Escolha o trecho para avaliar" "${menu_items[@]}") || return
+  if ! [[ "$selected" =~ ^[0-9]+$ ]]; then
+    show_alert "Feedback" "Identificador de chunk inválido: $selected"
+    return
+  fi
+  local signal_choice
+  signal_choice=$(choose_from_menu "Feedback" "Selecione o tipo" \
+    P "+1 Relevante" N "-1 Não relevante" Z "Neutro (0)") || return
+  local signal
+  case "$signal_choice" in
+    P) signal=1 ;;
+    N) signal=-1 ;;
+    Z) signal=0 ;;
+    *) signal=0 ;;
+  esac
+  detect_api_url
+  local payload tmp_resp curl_output http_code body
+  payload=$(jq -nc --arg q "$qhash" --argjson d "$selected" --argjson s "$signal" '{query_hash:$q, doc_id:$d, signal:$s}')
+  tmp_resp="$(mktemp)"
+  curl_output=$(curl -sS -o "$tmp_resp" -w '%{http_code}' -X POST "${API_ENDPOINT%/}/feedback" \
+    -H 'Content-Type: application/json' -d "$payload" 2>&1)
+  local curl_status=$?
+  if [[ $curl_status -ne 0 ]]; then
+    rm -f "$tmp_resp"
+    show_alert "Feedback" "Falha ao enviar: ${curl_output:-erro desconhecido}"
+    return
+  fi
+  http_code="${curl_output:(-3)}"
+  http_code="${http_code//$'\n'/}"; http_code="${http_code//$'\r'/}"
+  body="$(cat "$tmp_resp")"
+  rm -f "$tmp_resp"
+  if [[ "$http_code" =~ ^2 && ( -z "$body" || $(printf '%s' "$body" | jq -r '.ok // empty' 2>/dev/null) == "true" ) ]]; then
+    show_alert "Feedback" "Obrigado! Feedback registrado."
+  else
+    show_alert "Feedback" "Erro ${http_code}: ${body:-sem resposta}"
+  fi
+}
+
+main_menu(){
+  start_stack
+  while true; do
+    local CH
+    if command -v dialog >/dev/null 2>&1; then
+      dialog --menu "💬 Sophia – Chat (sessão: $SESSION)" 20 78 10 \
+        Q "Nova pergunta" F "Enviar feedback" B "Voltar" 2>/.tmp.sel || exit 0
+      CH="$(cat /.tmp.sel)"
+    else
+      CH=$(whiptail --title "💬 Sophia – Chat (sessão: $SESSION)" --menu "Selecione:" 20 78 10 \
+        Q "Nova pergunta" F "Enviar feedback" B "Voltar" 3>&1 1>&2 2>&3) || exit 0
+    fi
+    case "$CH" in
+      Q) send_question ;;
+      F) send_feedback ;;
+      B) exit 0 ;;
+    esac
+  done
+}
+
+main_menu


### PR DESCRIPTION
## Summary
- add a FastAPI feedback endpoint backed by psycopg and expose query/citation metadata from ask/chat handlers
- surface chunk identifiers in search utilities and update the chat TUI to post feedback to the API
- provide a small record_feedback.py helper for programmatic feedback submission

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cc864a1fc4832ba7a74d4069c8231f